### PR TITLE
Change image name parsing to prevent default docker registry domain addition

### DIFF
--- a/pkg/build/frontend.go
+++ b/pkg/build/frontend.go
@@ -141,7 +141,7 @@ func resolveStates(ctx context.Context, bopts *BOpts, platform ocispecs.Platform
 				return
 			}
 
-			ref, err := dref.ParseAnyReference(resolvedBaseStageName.Result)
+			ref, err := dref.Parse(resolvedBaseStageName.Result)
 			if err != nil {
 				if err == reference.ErrObjectRequired {
 					return


### PR DESCRIPTION
Fixes https://github.com/apple/container/issues/211

As a followup of the discussion in https://github.com/apple/container/pull/223 changing image name parsing to use a reference without default docker.io domain.