### PR TITLE
Move builder shim CI to use self hosted runners

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: [self-hosted, macos, sequoia, ARM64]
     timeout-minutes: 30
     steps: 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Previously we used the macOS latest runners from GitHub for availability reasons. Now that we have access to more runners, this is no longer needed. 