### PR TITLE
Remove use of triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: File a bug report.
 title: "[Bug]: "
-labels: ["triage"]
 type: "Bug"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,7 +1,6 @@
 name: Feature or enhancement request
 description: File a request for a feature or enhancement
 title: "[Request]: "
-labels: ["triage"]
 type: "Feature"
 body:
   - type: markdown


### PR DESCRIPTION
Tags on the repo should be a way to classify an item instead of denoting workflow or status of the item. Remove the addition of the triage label on bug and feature issues.

Related to https://github.com/apple/container/pull/262