### PR TITLE
Ignore resolving scratch and context images

### DIFF
--- a/pkg/build/frontend.go
+++ b/pkg/build/frontend.go
@@ -141,6 +141,10 @@ func resolveStates(ctx context.Context, bopts *BOpts, platform ocispecs.Platform
 				return
 			}
 
+			if strings.EqualFold(resolvedBaseStageName.Result, "scratch") || strings.EqualFold(resolvedBaseStageName.Result, "context") {
+				return
+			}
+
 			ref, err := dref.ParseAnyReference(resolvedBaseStageName.Result)
 			if err != nil {
 				if err == reference.ErrObjectRequired {


### PR DESCRIPTION
Buildkit flow that we call into does not allow for loading named contexts for "scratch" or "context" (see https://github.com/apple/container-builder-shim/blob/5c5c16824419e6bc88ee96e38eb566b8650079a8/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go#L213). We can ignore those images in builder-shim as well when we pre-resolve images. 