### PR TITLE
remove workflow permission restriction for common.yaml

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,8 +1,5 @@
 name: Container Builder Shim - common jobs
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
This PR removes workflow permission restriction for common.yaml to we can push images to ghcr.