### PR TITLE
Revert "remove workflow permission restriction for common.yaml (#48)"

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,5 +1,8 @@
 name: Container Builder Shim - common jobs
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
- This reverts commit 5b144611ee440aa0ccc484f6e24e7576af13611b.
- We'll rework the shared workflows when we have time.
- For now, shim publishing will be broken.