### PR TITLE
Add support for build secrets

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/cmd/buildctl/build"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/go-csvvalue"
 	"google.golang.org/grpc"
@@ -128,6 +129,7 @@ func Build(ctx context.Context, opts *BOpts) error {
 		CacheExports: cacheExports,
 		Session: []session.Attachable{
 			opts.FSSync,
+			secretsprovider.FromMap(opts.Secrets),
 		},
 		FrontendAttrs: map[string]string{},
 	}

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -214,30 +214,34 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		}
 		return args
 	}
-	mapExtractB64 := func(key string) map[string][]byte {
+	mapExtractB64 := func(key string) (map[string][]byte, error) {
 		values, ok := contextMap[key]
 		if !ok {
-			return map[string][]byte{}
+			return map[string][]byte{}, nil
 		}
 		args := map[string][]byte{}
 		for _, label := range values {
 			parts := strings.SplitN(label, "=", 2)
 			switch len(parts) {
 			case 1:
-				args[parts[0]] = []byte("")
+				args[parts[0]] = []byte{}
 			case 2:
 				dat, err := base64.StdEncoding.DecodeString(parts[1])
-				if err == nil {
-					args[parts[0]] = dat
+				if err != nil {
+					return nil, err
 				}
+				args[parts[0]] = dat
 			}
 		}
-		return args
+		return args, nil
 	}
 
 	labels := mapExtract(KeyLabels)
 	buildArgs := mapExtract(KeyBuildArgs)
-	secrets := mapExtractB64(KeySecrets)
+	secrets, err := mapExtractB64(KeySecrets)
+	if err != nil {
+		return nil, err
+	}
 	cacheIn := contextMap[KeyCacheIn]
 	cacheOut := contextMap[KeyCacheOut]
 	outputs := contextMap[KeyOutput]

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -61,6 +61,8 @@ const (
 	KeyLabels = "labels"
 	// ARG key=value pairs passed to the Dockerfile.
 	KeyBuildArgs = "build-args"
+	// RUN --mount=type=secret,... id:value pairs passed to the Dockerfile.
+	KeySecrets = "secrets"
 	// Cache import sources.
 	KeyCacheIn = "cache-in"
 	// Cache export destinations.
@@ -88,6 +90,7 @@ type BOpts struct {
 	NoCache        bool
 	Target         string
 	BuildArgs      map[string]string
+	Secrets        map[string][]byte
 	CacheIn        []string
 	CacheOut       []string
 	Outputs        []string
@@ -211,9 +214,30 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		}
 		return args
 	}
+	mapExtractB64 := func(key string) map[string][]byte {
+		values, ok := contextMap[key]
+		if !ok {
+			return map[string][]byte{}
+		}
+		args := map[string][]byte{}
+		for _, label := range values {
+			parts := strings.SplitN(label, "=", 2)
+			switch len(parts) {
+			case 1:
+				args[parts[0]] = []byte("")
+			case 2:
+				dat, err := base64.StdEncoding.DecodeString(parts[1])
+				if err == nil {
+					args[parts[0]] = dat
+				}
+			}
+		}
+		return args
+	}
 
 	labels := mapExtract(KeyLabels)
 	buildArgs := mapExtract(KeyBuildArgs)
+	secrets := mapExtractB64(KeySecrets)
 	cacheIn := contextMap[KeyCacheIn]
 	cacheOut := contextMap[KeyCacheOut]
 	outputs := contextMap[KeyOutput]
@@ -305,6 +329,7 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		Target:         target,
 		Labels:         labels,
 		BuildArgs:      buildArgs,
+		Secrets:        secrets,
 		CacheIn:        cacheIn,
 		CacheOut:       cacheOut,
 		Outputs:        outputs,


### PR DESCRIPTION
New feature: docker-compatible `--secret id=key,...` arg for `container build`, that works with Dockerfiles with `RUN --mount=type=secret`