### PR TITLE
[build]: fix dockerfile build args parsing

### DIFF
--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -161,16 +161,6 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		bps = append(bps, platforms.DefaultSpec())
 	}
 
-	normalizeBuildArg := func(arg string) string {
-		arg = strings.TrimSpace(arg)
-		if len(arg) >= 2 {
-			if (arg[0] == '"' && arg[len(arg)-1] == '"') || (arg[0] == '\'' && arg[len(arg)-1] == '\'') {
-				arg = arg[1 : len(arg)-1]
-			}
-		}
-		return arg
-	}
-
 	pls, err := func() ([]ocispecs.Platform, error) {
 		pls := []ocispecs.Platform{}
 		values, ok := contextMap[KeyPlatforms]
@@ -271,7 +261,7 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 				return nil, err
 			}
 			// Save the resolved value for later use
-			buildArgs[arg.Key] = normalizeBuildArg(resolved.Result)
+			buildArgs[arg.Key] = resolved.Result
 		}
 	}
 

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -160,6 +161,16 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		bps = append(bps, platforms.DefaultSpec())
 	}
 
+	normalizeBuildArg := func(arg string) string {
+		arg = strings.TrimSpace(arg)
+		if len(arg) >= 2 {
+			if (arg[0] == '"' && arg[len(arg)-1] == '"') || (arg[0] == '\'' && arg[len(arg)-1] == '\'') {
+				arg = arg[1 : len(arg)-1]
+			}
+		}
+		return arg
+	}
+
 	pls, err := func() ([]ocispecs.Platform, error) {
 		pls := []ocispecs.Platform{}
 		values, ok := contextMap[KeyPlatforms]
@@ -251,9 +262,16 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 	for _, metaArg := range metaArgs {
 		for _, arg := range metaArg.Args {
 			// Only use the dockerfile meta arg if the user did not overwrite it
-			if _, ok := buildArgs[arg.Key]; !ok {
-				buildArgs[arg.Key] = arg.ValueString()
+			if _, ok := buildArgs[arg.Key]; ok {
+				continue
 			}
+			// Expand with prior args and strip shell quotes
+			resolved, err := shell.NewLex('\\').ProcessWordWithMatches(arg.ValueString(), utils.NewMapGetter(buildArgs))
+			if err != nil {
+				return nil, err
+			}
+			// Save the resolved value for later use
+			buildArgs[arg.Key] = normalizeBuildArg(resolved.Result)
 		}
 	}
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Closes https://github.com/apple/container/issues/1295

Normalize quoted build args so the `Dockerfile` sees the correct value passed through the build pipeline. When using the `--build-arg` flag, any quoted value is stripped by one layer, which is the correct behavior. 

However, passing a `Dockerfile` default like below was being literally read and caused reference issues. 

```dockerfile
# Passed value
ARG PYTHON_IMAGE="python:3.13-slim"
# Normalized
ARG PYTHON_IMAGE=python:3.13-slim
``` 

If the intent is to pass a quoted value, only one layer of quotes is stripped, so it is kept intact with proper quotes.

```dockerfile
# Passed value
ARG MYSTRING='"Hello, world!"'
# Normalized
ARG MYSTRING="Hello, world!"
```

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs