### PR TITLE
Do not make hidden directory inside builder shim

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/cmd/buildctl/build"
 	"github.com/moby/buildkit/session"
+	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/go-csvvalue"
 	"google.golang.org/grpc"
 )
@@ -50,6 +51,7 @@ func Build(ctx context.Context, opts *BOpts) error {
 
 	buildkit, err := client.New(ctx, "", clientOpts...)
 	if err != nil {
+		logrus.Debugf("failed to connect to buildkit")
 		return err
 	}
 	defer buildkit.Close()

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,7 +30,6 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/cmd/buildctl/build"
 	"github.com/moby/buildkit/session"
-	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/go-csvvalue"
 	"google.golang.org/grpc"
 )
@@ -51,7 +50,6 @@ func Build(ctx context.Context, opts *BOpts) error {
 
 	buildkit, err := client.New(ctx, "", clientOpts...)
 	if err != nil {
-		logrus.Debugf("failed to connect to buildkit")
 		return err
 	}
 	defer buildkit.Close()
@@ -135,8 +133,8 @@ func Build(ctx context.Context, opts *BOpts) error {
 		KeyContentStoreName: opts.ContentStore,
 	}
 
-	if opts.HiddenDirName != "" {
-		solveOpt.FrontendAttrs["filename"] = filepath.Join(opts.HiddenDirName, "Dockerfile")
+	if opts.HiddenDockerDir != "" {
+		solveOpt.FrontendAttrs["filename"] = filepath.Join(opts.HiddenDockerDir, "Dockerfile")
 	}
 
 	if opts.NoCache {

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -20,12 +20,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/containerd/platforms"
-	"github.com/google/uuid"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/util/progress/progresswriter"
@@ -43,8 +41,9 @@ const (
 	KeyContentStoreName = "container"
 	// Base64-encoded Dockerfile contents.
 	KeyDockerfile = "dockerfile"
-	// Base64-encoded docker specific ignore file contents.
-	KeyDockerignore = "dockerignore"
+	// Hidden directory for the dockerfile to be placed.
+	// Used when docker specific ignore file is found.
+	KeyHiddenDockerDir = "hidden-docker-dir"
 	// Image reference (name:tag) to assign to the built image.
 	KeyTag = "tag"
 	// Target platforms to build the image for.
@@ -78,21 +77,21 @@ const (
 var keyBOpts = struct{}{}
 
 type BOpts struct {
-	BuildID        string
-	Dockerfile     []byte
-	Tag            string
-	ContextDir     string
-	HiddenDirName  string
-	BuildPlatforms []ocispecs.Platform
-	Platforms      []ocispecs.Platform
-	NoCache        bool
-	Target         string
-	BuildArgs      map[string]string
-	CacheIn        []string
-	CacheOut       []string
-	Outputs        []string
-	Labels         map[string]string
-	ProgressWriter progresswriter.Writer
+	BuildID         string
+	Dockerfile      []byte
+	Tag             string
+	ContextDir      string
+	HiddenDockerDir string
+	BuildPlatforms  []ocispecs.Platform
+	Platforms       []ocispecs.Platform
+	NoCache         bool
+	Target          string
+	BuildArgs       map[string]string
+	CacheIn         []string
+	CacheOut        []string
+	Outputs         []string
+	Labels          map[string]string
+	ProgressWriter  progresswriter.Writer
 
 	ContentStore *content.ContentStoreProxy
 	Resolver     *resolver.ResolverProxy
@@ -126,19 +125,7 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		return nil, err
 	}
 
-	var dockerignoreBytes = []byte(nil)
-	var hiddenDirName = ""
-
-	dockerignoreBase64Bytes, ok := first(KeyDockerignore)
-	if ok {
-		dockerignoreBytes, err = base64.StdEncoding.DecodeString(dockerignoreBase64Bytes)
-		if err != nil {
-			return nil, err
-		}
-
-		hiddenDirName = ".tmp-" + uuid.NewString()
-		dockerignoreBytes = append(dockerignoreBytes, fmt.Sprintf("\n%s", hiddenDirName)...)
-	}
+	hiddenDockerDir, _ := first(KeyHiddenDockerDir)
 
 	progress, ok := first(KeyProgress)
 	if !ok {
@@ -278,7 +265,7 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		}
 	}
 
-	fssyncProxy, err := fssync.NewFSSyncProxy(".", basePath, hiddenDirName, dockerfileBytes, dockerignoreBytes, addedGlobs)
+	fssyncProxy, err := fssync.NewFSSyncProxy(".", basePath, addedGlobs)
 	if err != nil {
 		return nil, err
 	}
@@ -289,26 +276,26 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 	}
 
 	bopts := &BOpts{
-		BuildID:        buildID,
-		Dockerfile:     dockerfileBytes,
-		Tag:            tag,
-		BuildPlatforms: bps,
-		Platforms:      pls,
-		ContextDir:     ctxDir,
-		HiddenDirName:  hiddenDirName,
-		ContentStore:   contentProxy,
-		FSSync:         fssyncProxy,
-		NoCache:        noCache,
-		Resolver:       resolver.NewResolverProxy(),
-		ProgressWriter: pw,
-		Stdio:          stdioProxy,
-		Target:         target,
-		Labels:         labels,
-		BuildArgs:      buildArgs,
-		CacheIn:        cacheIn,
-		CacheOut:       cacheOut,
-		Outputs:        outputs,
-		basePath:       filepath.Join(basePath, buildID),
+		BuildID:         buildID,
+		Dockerfile:      dockerfileBytes,
+		Tag:             tag,
+		BuildPlatforms:  bps,
+		Platforms:       pls,
+		ContextDir:      ctxDir,
+		HiddenDockerDir: hiddenDockerDir,
+		ContentStore:    contentProxy,
+		FSSync:          fssyncProxy,
+		NoCache:         noCache,
+		Resolver:        resolver.NewResolverProxy(),
+		ProgressWriter:  pw,
+		Stdio:           stdioProxy,
+		Target:          target,
+		Labels:          labels,
+		BuildArgs:       buildArgs,
+		CacheIn:         cacheIn,
+		CacheOut:        cacheOut,
+		Outputs:         outputs,
+		basePath:        filepath.Join(basePath, buildID),
 	}
 
 	return bopts, nil

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -41,8 +41,8 @@ const (
 	KeyContentStoreName = "container"
 	// Base64-encoded Dockerfile contents.
 	KeyDockerfile = "dockerfile"
-	// Hidden directory for the dockerfile to be placed.
-	// Used when docker specific ignore file is found.
+	// Hidden directory for the dockerfile and dockerignore to be placed.
+	// This is provided when docker specific ignore file is found, which might live outside the build context.
 	KeyHiddenDockerDir = "hidden-docker-dir"
 	// Image reference (name:tag) to assign to the built image.
 	KeyTag = "tag"

--- a/pkg/fileutils/tarxfer.go
+++ b/pkg/fileutils/tarxfer.go
@@ -40,13 +40,7 @@ func NewTarReceiver(cacheBase string, demux *stream.Demultiplexer) *Receiver {
 	return &Receiver{demux: demux, cacheBase: cacheBase}
 }
 
-func (r *Receiver) Receive(
-	ctx context.Context,
-	hiddenDirName string,
-	dockerfileBytes []byte,
-	dockerignoreBytes []byte,
-	fn fs.WalkDirFunc) (string, error) {
-
+func (r *Receiver) Receive(ctx context.Context, fn fs.WalkDirFunc) (string, error) {
 	errCh := make(chan error, 1)
 	hashCh := make(chan string, 1)
 	dataCh := make(chan []byte)
@@ -89,36 +83,6 @@ func (r *Receiver) Receive(
 			return "", err
 		}
 		_ = os.Remove(tarFile)
-	}
-
-	if hiddenDirName != "" {
-		dockerfilePath := filepath.Join(cacheDir, filepath.Join(hiddenDirName, "Dockerfile"))
-		dockerignorePath := filepath.Join(cacheDir, filepath.Join(hiddenDirName, "Dockerfile.dockerignore"))
-
-		if err := os.MkdirAll(filepath.Dir(dockerfilePath), 0o755); err != nil {
-			return "", err
-		}
-
-		dockerfile, err := os.OpenFile(dockerfilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			return "", err
-		}
-		if _, err := dockerfile.Write(dockerfileBytes); err != nil {
-			_ = dockerfile.Close()
-			return "", err
-		}
-		defer dockerfile.Close()
-
-		dockerignore, err := os.OpenFile(dockerignorePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			return "", err
-		}
-		defer dockerignore.Close()
-
-		if _, err := dockerignore.Write(dockerignoreBytes); err != nil {
-			_ = dockerignore.Close()
-			return "", err
-		}
 	}
 
 	return checksum, filepath.Walk(cacheDir, func(p string, info os.FileInfo, _ error) error {

--- a/pkg/fileutils/tarxfer_test.go
+++ b/pkg/fileutils/tarxfer_test.go
@@ -95,7 +95,7 @@ func TestReceiver_Receive_Success(t *testing.T) {
 		return nil
 	}
 
-	checksum, err := r.Receive(ctx, "", nil, nil, walkFn)
+	checksum, err := r.Receive(ctx, walkFn)
 	if err != nil {
 		t.Fatalf("Receive returned error: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestReceiver_Receive_ServerError(t *testing.T) {
 	tmpDir := t.TempDir()
 	r := NewTarReceiver(tmpDir, demux)
 
-	_, err := r.Receive(ctx, "", nil, nil, func(string, fs.DirEntry, error) error { return nil })
+	_, err := r.Receive(ctx, func(string, fs.DirEntry, error) error { return nil })
 	if err == nil {
 		t.Fatalf("expected server error, got nil")
 	}

--- a/pkg/fssync/fssync.go
+++ b/pkg/fssync/fssync.go
@@ -45,23 +45,14 @@ type FSSyncProxy struct {
 	contextDir string
 	basePath   string
 
-	hiddenDirName string
-	dockerfile    []byte
-	dockerignore  []byte
-
 	addedGlobs []string
 }
 
-func NewFSSyncProxy(
-	contextDir string, basePath string, hiddenDirName string,
-	dockerfile []byte, dockerignore []byte, addedGlobs []string) (*FSSyncProxy, error) {
+func NewFSSyncProxy(contextDir string, basePath string, addedGlobs []string) (*FSSyncProxy, error) {
 
 	f := new(FSSyncProxy)
 	f.contextDir = contextDir
 	f.basePath = filepath.Join(basePath, f.String())
-	f.hiddenDirName = hiddenDirName
-	f.dockerfile = dockerfile
-	f.dockerignore = dockerignore
 	f.addedGlobs = addedGlobs
 	return f, nil
 }

--- a/pkg/fssync/walk.go
+++ b/pkg/fssync/walk.go
@@ -124,15 +124,14 @@ func (f *FS) Walk(ctx context.Context, target string, fn fs.WalkDirFunc) error {
 	switch walkMeta.Mode {
 	case ModeTAR:
 		receiver := fileutils.NewTarReceiver(f.fsPath, demux)
-		checksum, err := receiver.Receive(ctx, f.proxy.hiddenDirName, f.proxy.dockerfile, f.proxy.dockerignore,
-			func(path string, d fs.DirEntry, err error) error {
-				excluded, err := excludeMatcher.MatchesOrParentMatches(path)
-				if excluded {
-					return nil
-				}
+		checksum, err := receiver.Receive(ctx, func(path string, d fs.DirEntry, err error) error {
+			excluded, err := excludeMatcher.MatchesOrParentMatches(path)
+			if excluded {
+				return nil
+			}
 
-				return fn(path, d, err)
-			})
+			return fn(path, d, err)
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previous docker ignore fix (#68) has race bug when syncing files to the buildkit daemon. Upon file request from buildkitd, the FSSync proxy in builder shim checks `_checksum` variable to check if build context is synced inside VM, and responds differently: i) if not, it forwards a request to the proxy outside to get the file, ii) if synced, it immediately provides the file.

However, since #68 creates a hidden docker directory inside builder shim during sync, if the request for Dockerfile is received before the sync, it just forwards the request outside, which doesn't know that hidden directory.

This PR assumes the directory is created outside, so that such request can be handled.