### PR TITLE
Fix using docker specific ignore with read-only build context

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -138,9 +138,8 @@ func Build(ctx context.Context, opts *BOpts) error {
 	}
 
 	if len(opts.Dockerignore) > 0 {
-		solveOpt.FrontendAttrs["filename"] = "com.apple.container/Dockerfile"
+		solveOpt.FrontendAttrs["filename"] = filepath.Join(DockerfileStaging, "Dockerfile")
 	}
-	logrus.Debugf("solveOpt.FrontendAttrs[filename]=%v", solveOpt.FrontendAttrs["filename"])
 
 	if opts.NoCache {
 		solveOpt.FrontendAttrs["no-cache"] = ""

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -137,9 +137,10 @@ func Build(ctx context.Context, opts *BOpts) error {
 		KeyContentStoreName: opts.ContentStore,
 	}
 
-	if opts.HiddenDockerDir != "" {
-		solveOpt.FrontendAttrs["filename"] = filepath.Join(opts.HiddenDockerDir, "Dockerfile")
+	if len(opts.Dockerignore) > 0 {
+		solveOpt.FrontendAttrs["filename"] = "com.apple.container/Dockerfile"
 	}
+	logrus.Debugf("solveOpt.FrontendAttrs[filename]=%v", solveOpt.FrontendAttrs["filename"])
 
 	if opts.NoCache {
 		solveOpt.FrontendAttrs["no-cache"] = ""

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 
 	"github.com/apple/container-builder-shim/pkg/build/utils"
 	"github.com/apple/container-builder-shim/pkg/content"
@@ -41,9 +42,8 @@ const (
 	KeyContentStoreName = "container"
 	// Base64-encoded Dockerfile contents.
 	KeyDockerfile = "dockerfile"
-	// Hidden directory for the dockerfile and dockerignore to be placed.
-	// This is provided when docker specific ignore file is found, which might live outside the build context.
-	KeyHiddenDockerDir = "hidden-docker-dir"
+	// Base64-encoded Dockerignore contents.
+	KeyDockerignore = "dockerignore"
 	// Image reference (name:tag) to assign to the built image.
 	KeyTag = "tag"
 	// Target platforms to build the image for.
@@ -79,22 +79,22 @@ const (
 var keyBOpts = struct{}{}
 
 type BOpts struct {
-	BuildID         string
-	Dockerfile      []byte
-	Tag             string
-	ContextDir      string
-	HiddenDockerDir string
-	BuildPlatforms  []ocispecs.Platform
-	Platforms       []ocispecs.Platform
-	NoCache         bool
-	Target          string
-	BuildArgs       map[string]string
-	Secrets         map[string][]byte
-	CacheIn         []string
-	CacheOut        []string
-	Outputs         []string
-	Labels          map[string]string
-	ProgressWriter  progresswriter.Writer
+	BuildID        string
+	Dockerfile     []byte
+	Dockerignore   []byte
+	Tag            string
+	ContextDir     string
+	BuildPlatforms []ocispecs.Platform
+	Platforms      []ocispecs.Platform
+	NoCache        bool
+	Target         string
+	BuildArgs      map[string]string
+	Secrets        map[string][]byte
+	CacheIn        []string
+	CacheOut       []string
+	Outputs        []string
+	Labels         map[string]string
+	ProgressWriter progresswriter.Writer
 
 	ContentStore *content.ContentStoreProxy
 	Resolver     *resolver.ResolverProxy
@@ -128,7 +128,15 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		return nil, err
 	}
 
-	hiddenDockerDir, _ := first(KeyHiddenDockerDir)
+	dockerignoreBase64Bytes, ok := first(KeyDockerignore)
+
+	dockerignoreBytes := []byte{}
+	if ok {
+		dockerignoreBytes, err = base64.StdEncoding.DecodeString(dockerignoreBase64Bytes)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	progress, ok := first(KeyProgress)
 	if !ok {
@@ -293,7 +301,7 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		}
 	}
 
-	fssyncProxy, err := fssync.NewFSSyncProxy(".", basePath, addedGlobs)
+	fssyncProxy, err := fssync.NewFSSyncProxy(".", basePath, addedGlobs, dockerfileBytes, dockerignoreBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -304,28 +312,30 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 	}
 
 	bopts := &BOpts{
-		BuildID:         buildID,
-		Dockerfile:      dockerfileBytes,
-		Tag:             tag,
-		BuildPlatforms:  bps,
-		Platforms:       pls,
-		ContextDir:      ctxDir,
-		HiddenDockerDir: hiddenDockerDir,
-		ContentStore:    contentProxy,
-		FSSync:          fssyncProxy,
-		NoCache:         noCache,
-		Resolver:        resolver.NewResolverProxy(),
-		ProgressWriter:  pw,
-		Stdio:           stdioProxy,
-		Target:          target,
-		Labels:          labels,
-		BuildArgs:       buildArgs,
-		Secrets:         secrets,
-		CacheIn:         cacheIn,
-		CacheOut:        cacheOut,
-		Outputs:         outputs,
-		basePath:        filepath.Join(basePath, buildID),
+		BuildID:        buildID,
+		Dockerfile:     dockerfileBytes,
+		Dockerignore:   dockerignoreBytes,
+		Tag:            tag,
+		BuildPlatforms: bps,
+		Platforms:      pls,
+		ContextDir:     ctxDir,
+		ContentStore:   contentProxy,
+		FSSync:         fssyncProxy,
+		NoCache:        noCache,
+		Resolver:       resolver.NewResolverProxy(),
+		ProgressWriter: pw,
+		Stdio:          stdioProxy,
+		Target:         target,
+		Labels:         labels,
+		BuildArgs:      buildArgs,
+		Secrets:        secrets,
+		CacheIn:        cacheIn,
+		CacheOut:       cacheOut,
+		Outputs:        outputs,
+		basePath:       filepath.Join(basePath, buildID),
 	}
+
+	logrus.Debugf("bopts.Dockerignore: %v", string(dockerignoreBytes))
 
 	return bopts, nil
 }

--- a/pkg/build/buildopts.go
+++ b/pkg/build/buildopts.go
@@ -28,7 +28,6 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 
 	"github.com/apple/container-builder-shim/pkg/build/utils"
 	"github.com/apple/container-builder-shim/pkg/content"
@@ -73,7 +72,11 @@ const (
 )
 
 const (
+	// Used to share built artifacts outside VM
 	GlobalExportPath = "/var/lib/container-builder-shim/exports"
+	// If KeyDockerignore argument is provided, Dockerfile and ignore file are
+	// staged at DockerfileStaging directory, and buildkit uses them.
+	DockerfileStaging = fssync.DockerfileStaging
 )
 
 var keyBOpts = struct{}{}
@@ -136,6 +139,8 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		if err != nil {
 			return nil, err
 		}
+
+		dockerignoreBytes = append(dockerignoreBytes, []byte("\n"+DockerfileStaging)...)
 	}
 
 	progress, ok := first(KeyProgress)
@@ -334,8 +339,6 @@ func NewBuildOpts(ctx context.Context, basePath string, contextMap map[string][]
 		Outputs:        outputs,
 		basePath:       filepath.Join(basePath, buildID),
 	}
-
-	logrus.Debugf("bopts.Dockerignore: %v", string(dockerignoreBytes))
 
 	return bopts, nil
 }

--- a/pkg/fileutils/tarxfer.go
+++ b/pkg/fileutils/tarxfer.go
@@ -278,6 +278,9 @@ func unpackTar(ctx context.Context, tarFile, dest string) error {
 		if err != nil {
 			return err
 		}
+		if hdr.Name == DockerfileStaging {
+			return fmt.Errorf("cannot use reserved path: %s", hdr.Name)
+		}
 		target := filepath.Join(dest, hdr.Name)
 		if !strings.HasPrefix(target, filepath.Clean(dest)+string(os.PathSeparator)) {
 			return fmt.Errorf("invalid tar path: %s", hdr.Name)

--- a/pkg/fileutils/tarxfer.go
+++ b/pkg/fileutils/tarxfer.go
@@ -26,9 +26,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/apple/container-builder-shim/pkg/fssync"
 	"github.com/apple/container-builder-shim/pkg/stream"
 )
+
+const DockerfileStaging = ".com.apple.container"
 
 // Receiver streams a remote tar archive, caches it under cacheBase and calls fn
 // for every entry that is a regular file, directory or symlink.
@@ -319,7 +320,7 @@ func unpackTar(ctx context.Context, tarFile, dest string) error {
 }
 
 func stageDockerfiles(ctx context.Context, cacheDir string, dockerfile, dockerignore []byte) error {
-	staging := filepath.Join(cacheDir, fssync.DockerfileStaging)
+	staging := filepath.Join(cacheDir, DockerfileStaging)
 	if err := os.MkdirAll(staging, 0o755); err != nil {
 		return err
 	}

--- a/pkg/fileutils/tarxfer.go
+++ b/pkg/fileutils/tarxfer.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/apple/container-builder-shim/pkg/fssync"
 	"github.com/apple/container-builder-shim/pkg/stream"
 )
 
@@ -40,7 +41,7 @@ func NewTarReceiver(cacheBase string, demux *stream.Demultiplexer) *Receiver {
 	return &Receiver{demux: demux, cacheBase: cacheBase}
 }
 
-func (r *Receiver) Receive(ctx context.Context, fn fs.WalkDirFunc) (string, error) {
+func (r *Receiver) Receive(ctx context.Context, dockerfile, dockerignore []byte, fn fs.WalkDirFunc) (string, error) {
 	errCh := make(chan error, 1)
 	hashCh := make(chan string, 1)
 	dataCh := make(chan []byte)
@@ -83,6 +84,12 @@ func (r *Receiver) Receive(ctx context.Context, fn fs.WalkDirFunc) (string, erro
 			return "", err
 		}
 		_ = os.Remove(tarFile)
+	}
+
+	if len(dockerignore) > 0 {
+		if err := stageDockerfiles(ctx, cacheDir, dockerfile, dockerignore); err != nil {
+			return "", err
+		}
 	}
 
 	return checksum, filepath.Walk(cacheDir, func(p string, info os.FileInfo, _ error) error {
@@ -308,5 +315,30 @@ func unpackTar(ctx context.Context, tarFile, dest string) error {
 			}
 		}
 	}
+	return nil
+}
+
+func stageDockerfiles(ctx context.Context, cacheDir string, dockerfile, dockerignore []byte) error {
+	staging := filepath.Join(cacheDir, fssync.DockerfileStaging)
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		return err
+	}
+
+	dockerfilePath := filepath.Join(staging, "Dockerfile")
+	f, err := os.OpenFile(dockerfilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	f.Write(dockerfile)
+	f.Close()
+
+	dockerignorePath := filepath.Join(staging, "Dockerfile.dockerignore")
+	f, err = os.OpenFile(dockerignorePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	f.Write(dockerignore)
+	f.Close()
+
 	return nil
 }

--- a/pkg/fileutils/tarxfer.go
+++ b/pkg/fileutils/tarxfer.go
@@ -42,7 +42,7 @@ func NewTarReceiver(cacheBase string, demux *stream.Demultiplexer) *Receiver {
 	return &Receiver{demux: demux, cacheBase: cacheBase}
 }
 
-func (r *Receiver) Receive(ctx context.Context, dockerfile, dockerignore []byte, fn fs.WalkDirFunc) (string, error) {
+func (r *Receiver) Receive(ctx context.Context, dockerfile []byte, dockerignore []byte, fn fs.WalkDirFunc) (string, error) {
 	errCh := make(chan error, 1)
 	hashCh := make(chan string, 1)
 	dataCh := make(chan []byte)

--- a/pkg/fileutils/tarxfer.go
+++ b/pkg/fileutils/tarxfer.go
@@ -322,7 +322,7 @@ func unpackTar(ctx context.Context, tarFile, dest string) error {
 	return nil
 }
 
-func stageDockerfiles(ctx context.Context, cacheDir string, dockerfile, dockerignore []byte) error {
+func stageDockerfiles(ctx context.Context, cacheDir string, dockerfile []byte, dockerignore []byte) error {
 	staging := filepath.Join(cacheDir, DockerfileStaging)
 	if err := os.MkdirAll(staging, 0o755); err != nil {
 		return err

--- a/pkg/fileutils/tarxfer_test.go
+++ b/pkg/fileutils/tarxfer_test.go
@@ -95,7 +95,7 @@ func TestReceiver_Receive_Success(t *testing.T) {
 		return nil
 	}
 
-	checksum, err := r.Receive(ctx, walkFn)
+	checksum, err := r.Receive(ctx, []byte{}, []byte{}, walkFn)
 	if err != nil {
 		t.Fatalf("Receive returned error: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestReceiver_Receive_ServerError(t *testing.T) {
 	tmpDir := t.TempDir()
 	r := NewTarReceiver(tmpDir, demux)
 
-	_, err := r.Receive(ctx, func(string, fs.DirEntry, error) error { return nil })
+	_, err := r.Receive(ctx, []byte{}, []byte{}, func(string, fs.DirEntry, error) error { return nil })
 	if err == nil {
 		t.Fatalf("expected server error, got nil")
 	}

--- a/pkg/fssync/diffcopy.go
+++ b/pkg/fssync/diffcopy.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"sync"
 	"syscall"
 
@@ -150,9 +151,9 @@ func (s *sender) sendFile(h *sendHandle) error {
 	defer bufPool.Put(buf)
 
 	switch h.path {
-	case "com.apple.container/Dockerfile":
+	case filepath.Join(DockerfileStaging, "Dockerfile"):
 		r = bytes.NewReader(s.fs.proxy.dockerfile)
-	case "com.apple.container/Dockerfile.ignore":
+	case filepath.Join(DockerfileStaging, "Dockerfile.dockerignore"):
 		r = bytes.NewReader(s.fs.proxy.dockerignore)
 	}
 
@@ -201,24 +202,6 @@ func (s *sender) walk(ctx context.Context) error {
 	})
 	if err != nil {
 		return err
-	}
-
-	proxy := s.fs.proxy
-	syntheticStats := []*types.Stat{
-		{Path: "com.apple.container", Mode: uint32(os.ModeDir | 0755)},
-		{Path: "com.apple.container/Dockerfile", Mode: uint32(0644), Size: int64(len(proxy.dockerfile))},
-		{Path: "com.apple.container/Dockerfile.ignore", Mode: uint32(0644), Size: int64(len(proxy.dockerignore))},
-	}
-	for _, stat := range syntheticStats {
-		if fileCanRequestData(os.FileMode(stat.Mode)) {
-			s.mu.Lock()
-			s.files[i] = stat.Path
-			s.mu.Unlock()
-		}
-		i++
-		if err := s.conn.SendMsg(&types.Packet{Type: types.PACKET_STAT, Stat: stat}); err != nil {
-			return errors.Wrapf(err, "failed to send stat %s", stat.Path)
-		}
 	}
 
 	return errors.Wrapf(s.conn.SendMsg(&types.Packet{Type: types.PACKET_STAT}), "failed to send last stat")

--- a/pkg/fssync/diffcopy.go
+++ b/pkg/fssync/diffcopy.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/fsutil/types"
 	"golang.org/x/sync/errgroup"
 )
@@ -144,8 +143,6 @@ func (s *sender) queue(id uint32) error {
 }
 
 func (s *sender) sendFile(h *sendHandle) error {
-	logrus.Debugf("sendFile: %v", h.path)
-
 	var r io.Reader
 	buf := bufPool.Get().(*[]byte)
 	defer bufPool.Put(buf)

--- a/pkg/fssync/diffcopy.go
+++ b/pkg/fssync/diffcopy.go
@@ -17,6 +17,7 @@
 package fssync
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"io/fs"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/fsutil/types"
 	"golang.org/x/sync/errgroup"
 )
@@ -141,12 +143,29 @@ func (s *sender) queue(id uint32) error {
 }
 
 func (s *sender) sendFile(h *sendHandle) error {
-	f, err := s.fs.Open(h.path)
-	if err == nil {
-		defer f.Close()
-		buf := bufPool.Get().(*[]byte)
-		defer bufPool.Put(buf)
-		if _, err := io.CopyBuffer(&fileSender{sender: s, id: h.id}, struct{ io.Reader }{f}, *buf); err != nil {
+	logrus.Debugf("sendFile: %v", h.path)
+
+	var r io.Reader
+	buf := bufPool.Get().(*[]byte)
+	defer bufPool.Put(buf)
+
+	switch h.path {
+	case "com.apple.container/Dockerfile":
+		r = bytes.NewReader(s.fs.proxy.dockerfile)
+	case "com.apple.container/Dockerfile.ignore":
+		r = bytes.NewReader(s.fs.proxy.dockerignore)
+	}
+
+	if r == nil {
+		f, err := s.fs.Open(h.path)
+		if err == nil {
+			defer f.Close()
+			if _, err := io.CopyBuffer(&fileSender{sender: s, id: h.id}, struct{ io.Reader }{f}, *buf); err != nil {
+				return err
+			}
+		}
+	} else {
+		if _, err := io.CopyBuffer(&fileSender{sender: s, id: h.id}, r, *buf); err != nil {
 			return err
 		}
 	}
@@ -183,6 +202,25 @@ func (s *sender) walk(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	proxy := s.fs.proxy
+	syntheticStats := []*types.Stat{
+		{Path: "com.apple.container", Mode: uint32(os.ModeDir | 0755)},
+		{Path: "com.apple.container/Dockerfile", Mode: uint32(0644), Size: int64(len(proxy.dockerfile))},
+		{Path: "com.apple.container/Dockerfile.ignore", Mode: uint32(0644), Size: int64(len(proxy.dockerignore))},
+	}
+	for _, stat := range syntheticStats {
+		if fileCanRequestData(os.FileMode(stat.Mode)) {
+			s.mu.Lock()
+			s.files[i] = stat.Path
+			s.mu.Unlock()
+		}
+		i++
+		if err := s.conn.SendMsg(&types.Packet{Type: types.PACKET_STAT, Stat: stat}); err != nil {
+			return errors.Wrapf(err, "failed to send stat %s", stat.Path)
+		}
+	}
+
 	return errors.Wrapf(s.conn.SendMsg(&types.Packet{Type: types.PACKET_STAT}), "failed to send last stat")
 }
 

--- a/pkg/fssync/fssync.go
+++ b/pkg/fssync/fssync.go
@@ -46,14 +46,21 @@ type FSSyncProxy struct {
 	basePath   string
 
 	addedGlobs []string
+
+	dockerfile   []byte
+	dockerignore []byte
 }
 
-func NewFSSyncProxy(contextDir string, basePath string, addedGlobs []string) (*FSSyncProxy, error) {
+func NewFSSyncProxy(contextDir string, basePath string, addedGlobs []string,
+	dockerfile []byte, dockerignore []byte) (*FSSyncProxy, error) {
 
 	f := new(FSSyncProxy)
 	f.contextDir = contextDir
 	f.basePath = filepath.Join(basePath, f.String())
 	f.addedGlobs = addedGlobs
+
+	f.dockerfile = dockerfile
+	f.dockerignore = dockerignore
 	return f, nil
 }
 

--- a/pkg/fssync/fssync.go
+++ b/pkg/fssync/fssync.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const DockerfileStaging = ".com.apple.container"
+
 var (
 	_ stream.Stage            = &FSSyncProxy{}
 	_ session.Attachable      = &FSSyncProxy{}

--- a/pkg/fssync/fssync.go
+++ b/pkg/fssync/fssync.go
@@ -25,12 +25,13 @@ import (
 	"github.com/moby/buildkit/session/filesync"
 
 	"github.com/apple/container-builder-shim/pkg/api"
+	"github.com/apple/container-builder-shim/pkg/fileutils"
 	"github.com/apple/container-builder-shim/pkg/stream"
 
 	"google.golang.org/grpc"
 )
 
-const DockerfileStaging = ".com.apple.container"
+const DockerfileStaging = fileutils.DockerfileStaging
 
 var (
 	_ stream.Stage            = &FSSyncProxy{}

--- a/pkg/fssync/walk.go
+++ b/pkg/fssync/walk.go
@@ -124,14 +124,15 @@ func (f *FS) Walk(ctx context.Context, target string, fn fs.WalkDirFunc) error {
 	switch walkMeta.Mode {
 	case ModeTAR:
 		receiver := fileutils.NewTarReceiver(f.fsPath, demux)
-		checksum, err := receiver.Receive(ctx, func(path string, d fs.DirEntry, err error) error {
-			excluded, err := excludeMatcher.MatchesOrParentMatches(path)
-			if excluded {
-				return nil
-			}
+		checksum, err := receiver.Receive(ctx, f.proxy.dockerfile, f.proxy.dockerignore,
+			func(path string, d fs.DirEntry, err error) error {
+				excluded, err := excludeMatcher.MatchesOrParentMatches(path)
+				if excluded {
+					return nil
+				}
 
-			return fn(path, d, err)
-		})
+				return fn(path, d, err)
+			})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR resolves the issue when using docker specific ignore file with read-only build context (apple/container#1343).

Once the `dockerignore` argument is provided in `PerformBuild` gRPC, it performs following two operations.

First, after unpacking transferred build context archive into `cache` directory, it creates a `DockerfileStaging` (i.e., `.com.apple.container`) directory there, and copies `Dockerfile` and `Dockerfile.dockerignore`. The path to `DockerfileStaging` is passed to the buildkit daemon so that it can correctly figure out which dockerignore file to read.

Second, it handles data requests for `Dockerfile` and `Dockerfile.dockerignore` (i.e., `diffcopy.go:sender::sendFile`), so that the requests before the actual files are written can be correctly served---i.e., refer #71 for more context about this race issue.