### PR TITLE
Stream processor drops completion marker

### DIFF
--- a/pkg/fileutils/tarxfer_test.go
+++ b/pkg/fileutils/tarxfer_test.go
@@ -114,6 +114,92 @@ func TestReceiver_Receive_Success(t *testing.T) {
 	}
 }
 
+func TestReceiver_Receive_OverflowsDemuxChannel(t *testing.T) {
+	// Regression: a context transfer that produces more BuildTransfer
+	// packets than the demux channel can hold must not drop the
+	// complete=true marker. Accept must apply backpressure rather
+	// than drop. Without that, the receiver hung forever waiting on
+	// a packet that would never arrive.
+	archive, err := makeTar()
+	if err != nil {
+		t.Fatalf("makeTar: %v", err)
+	}
+	if len(archive) < 512 {
+		t.Fatalf("tar archive too small: %d", len(archive))
+	}
+	hashBytes := sha256.Sum256(archive)
+	hash := hex.EncodeToString(hashBytes[:])
+	header := archive[:512]
+	body := archive[512:]
+
+	// Split the body into enough chunks to exceed the demux channel
+	// capacity, forcing the producer to wait on backpressure.
+	const chunkSize = 16
+	chunks := make([][]byte, 0, len(body)/chunkSize+1)
+	for i := 0; i < len(body); i += chunkSize {
+		end := i + chunkSize
+		if end > len(body) {
+			end = len(body)
+		}
+		chunks = append(chunks, body[i:end])
+	}
+	for len(chunks) < 64 {
+		chunks = append(chunks, []byte{})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	demux := newDemux(ctx)
+
+	producerErr := make(chan error, 1)
+	go func() {
+		defer close(producerErr)
+		if err := demux.Accept(btPacket(nil, false, map[string]string{"hash": hash})); err != nil {
+			producerErr <- err
+			return
+		}
+		if err := demux.Accept(btPacket(header, false, nil)); err != nil {
+			producerErr <- err
+			return
+		}
+		for i, chunk := range chunks {
+			isLast := i == len(chunks)-1
+			if err := demux.Accept(btPacket(chunk, isLast, nil)); err != nil {
+				producerErr <- err
+				return
+			}
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	r := NewTarReceiver(tmpDir, demux)
+
+	var visited []string
+	walkFn := func(p string, _ fs.DirEntry, _ error) error {
+		visited = append(visited, p)
+		return nil
+	}
+
+	start := time.Now()
+	checksum, err := r.Receive(ctx, []byte{}, []byte{}, walkFn)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Receive failed after %v: %v", elapsed, err)
+	}
+	if err := <-producerErr; err != nil {
+		t.Fatalf("producer Accept failed: %v", err)
+	}
+	if checksum != hash {
+		t.Fatalf("checksum mismatch: want %s, got %s", hash, checksum)
+	}
+	if len(visited) != 1 || visited[0] != "file1" {
+		t.Fatalf("unexpected visited paths: %v", visited)
+	}
+	if fi, err := os.Stat(filepath.Join(tmpDir, checksum, "file1")); err != nil || !fi.Mode().IsRegular() {
+		t.Fatalf("extracted file missing or not regular: %v", err)
+	}
+}
+
 func TestReceiver_Receive_ServerError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/stream/errors.go
+++ b/pkg/stream/errors.go
@@ -27,7 +27,6 @@ var (
 	ErrNoHandlerFound    = errors.New("no handler found for packet")
 	ErrNotATTY           = errors.New("not a tty")
 	ErrSendStreamBlocked = errors.New("send stream is blocked")
-	ErrDemuxChannelFull  = errors.New("demux channel full")
 )
 
 type UninitializedStageErr string

--- a/pkg/stream/processor.go
+++ b/pkg/stream/processor.go
@@ -58,7 +58,9 @@ func (d *Demultiplexer) Closed() bool {
 	return d.ctx.Err() != nil
 }
 
-// Accept validates & enqueues a packet.
+// Accept enqueues a packet for the demux consumer. The send blocks
+// when the channel is full to apply backpressure. Returns the demux
+// ctx error if cancelled before the packet is enqueued.
 func (d *Demultiplexer) Accept(c *api.ClientStream) error {
 	if err := d.filter(c); err != nil {
 		return err
@@ -70,10 +72,6 @@ func (d *Demultiplexer) Accept(c *api.ClientStream) error {
 		return d.ctx.Err()
 	case d.ch <- c:
 		return nil
-	default:
-		// Channel is full - clean it up to prevent future packets from being sent here
-		d.closeFn(d.id)
-		return ErrDemuxChannelFull
 	}
 }
 


### PR DESCRIPTION
## Summary

`container build` can hang indefinitely  at "transferring context".
When this happens, the build must be killed manually. The hang
occurs intermittently and is sensitive to context size, disk latency,
and probably scheduler timing as well.

I tracked this issue to `Demultiplexer.Accept` in [container-build-shim][shim]
which silently drops packets when its 32-slot per-id channel is full, leaving the
consumer to wait forever on a packet that will never arrive. This
manifests as `container build` hanging indefinitely at
"transferring context" whenever a build context produces enough
packets to saturate the channel.

## Bug Details

`Demultiplexer.Accept` at [pkg/stream/processor.go][processor] uses a
non-blocking `select` whose `default` branch drops packets when
the channel is full:

```go
select {
case <-d.ctx.Done():
    d.closeFn(d.id)
    return d.ctx.Err()
case d.ch <- c:
    return nil
default:
    d.closeFn(d.id)
    return ErrDemuxChannelFull
}
```

On the FSSync `Walk` path, the `closeFn` is a no-op
([pkg/fssync/walk.go][walk]), so the demux ctx is not cancelled on
overflow. The consumer (`startTar` in [pkg/fileutils/tarxfer.go][tarxfer])
blocks indefinitely in `demux.Recv()` waiting for packets that were
dropped. The dropped packets can include the final `complete=true`
marker, so the receiver can never finish.

On the producer side, the host (MacOS) streams the context tar in 4 MiB chunks
([container/Sources/ContainerBuild/BuildFSSync.swift][buildfssync])
into a Swift `AsyncStream` created with the default unbounded buffering
policy ([Builder.swift][builder]), so the host produces at with no backpressure.
A slow consumer can easily saturate the 32-slot demux channel.

## Diagnosis

Captured live from a hung `container build` on my machine. Inside
the builder VM via `container logs buildkit`:

```text
20:56:03  session started
20:56:04  diffcopy took: 1.169s   load build definition from Dockerfile
20:56:05  diffcopy took: 1.026s   load .dockerignore
20:56:05  reusing ref for local: trg599mgn053v52gpzoabhryz   "[internal] load build context"
20:56:12  WARN  handler refused packet  build_id=bf31add0-... error="demux channel full" handler_closed=false
20:56:13  WARN  handler refused packet  build_id=bf31add0-... error="demux channel full" handler_closed=false
...      (~30 repetitions within ~1s)
(silence: no "diffcopy took: …" ever logged for this Walk)
```

The `handler_closed=false` field confirms the demux ctx is not
cancelled on overflow, matching the no-op `closeFn` in
[pkg/fssync/walk.go][walk]. The build hung for 13 minutes until
killed manually.

Running `sample` on the CLI process showed healthy stdio handling,
suggesting a hang inside the builder VM.

## Reproduction

A regression test in `pkg/fileutils/tarxfer_test.go` reproduces the
hang deterministically and validates the fix:

```bash
go test ./pkg/fileutils/... \
  -run TestReceiver_Receive_OverflowsDemuxChannel -race
```

The test streams a tar split into 64 small `BuildTransfer` packets
through the demux while the receiver consumes concurrently. Without
the fix, the receiver blocks until the test ctx times out. With the
fix, the producer waits on backpressure and all packets are
delivered.

## Proposed Fix

Remove the non-blocking `default` branch from
`Demultiplexer.Accept`. The send blocks on the bounded channel,
gated by `<-d.ctx.Done()`:

```go
select {
case <-d.ctx.Done():
    d.closeFn(d.id)
    return d.ctx.Err()
case d.ch <- c:
    return nil
}
```

Backpressure can propagate end-to-end, and the bounded
channel becomes a backpressure signal rather than a drop point.

The new pattern should be safe for all consumers. `startTar` and the
content-store readers are pure draining loops that never wait on a
future packet to make progress on the current one, so they cannot
deadlock with a blocked producer.


I considered cancelling the demux ctx on overflow (instead of blocking).
It would convert the hang into a prompt error but the build would still fail.

I also considered enlarging the channel from 32 to reduce the chance of
a race, but under sufficient producer pressure a buffer can still saturate.
Backpressure seemed like the best option. 

## Verification

- `go test ./...` passes.
- `TestReceiver_Receive_OverflowsDemuxChannel` passes 20 iterations
  under `-race`.
- `pkg/stream/...` passes 20 iterations under `-race`.

I also tested `container` end to end by overriding the builder to use my own.
 Using the builder image with the fix in this PR, I no longer observe the context
transfer hangs after many attempts to reproduce locally.

```shell
$ container system property set image.builder <ref>
```

[shim]: https://github.com/apple/container-builder-shim
[processor]: https://github.com/apple/container-builder-shim/blob/eeea34fd9bb36d4b06d77c50d3be39d498dbfe3f/pkg/stream/processor.go#L67
[walk]: https://github.com/apple/container-builder-shim/blob/eeea34fd9bb36d4b06d77c50d3be39d498dbfe3f/pkg/fssync/walk.go#L103
[tarxfer]: https://github.com/apple/container-builder-shim/blob/eeea34fd9bb36d4b06d77c50d3be39d498dbfe3f/pkg/fileutils/tarxfer.go#L131
[buildfssync]: https://github.com/apple/container/blob/0.12.3/Sources/ContainerBuild/BuildFSSync.swift#L252
[builder]: https://github.com/apple/container/blob/0.12.3/Sources/ContainerBuild/Builder.swift#L97